### PR TITLE
Switch MathJax CDN to CDNjs due to MathJax’s CDN shutdown.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,6 +4,6 @@
     Co-creator of <a href='https://offsetmyride.io'>Offset My Ride</a>.<br>
     Like what you see? My website is <a href='https://github.com/a5huynh/a5huynh.github.com'>open source!</a>
   </div>
-  <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 </body>
 </html>

--- a/_layouts/print.html
+++ b/_layouts/print.html
@@ -25,6 +25,6 @@
       <div class='grid_2'>&nbsp;</div>
     </div>
   </div>
-  <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 </body>
 </html>


### PR DESCRIPTION
See: https://www.mathjax.org/cdn-shutting-down/